### PR TITLE
AXBlueServiceTime.py - Fix compilation error

### DIFF
--- a/usr/lib/enigma2/python/Components/Converter/AXBlueServiceTime.py
+++ b/usr/lib/enigma2/python/Components/Converter/AXBlueServiceTime.py
@@ -9,7 +9,7 @@ from Components.Sources.Clock import Clock
 
 
 class AXBlueServiceTime(Poll, Converter, object):
-TYPE_STARTTIME = 0
+	TYPE_STARTTIME = 0
 	TYPE_ENDTIME = 1
 
 	def __init__(self, type):


### PR DESCRIPTION
"meta-oe-alliance/meta-oe/recipes-distros/openatv/plugins/enigma2-plugin-skins-ax-blue-fhd-4atv.bb:do_compile) failed with exit code '1'"
Sorry: IndentationError: expected an indented block (AXBlueServiceTime.py, line 12)